### PR TITLE
Fix OXU.AZ scraping by adding Brotli support

### DIFF
--- a/scraper/requirements.txt
+++ b/scraper/requirements.txt
@@ -6,3 +6,4 @@ lxml>=4.9.3
 google-generativeai>=0.3.0
 aiohttp>=3.9.0
 aiofiles>=23.0.0
+Brotli>=1.0.0


### PR DESCRIPTION
- Added Brotli>=1.0.0 to requirements.txt to fix brotli encoding errors
- OXU.AZ was failing with "Can not decode content-encoding: brotli (br)"
- This will enable successful scraping from OXU.AZ